### PR TITLE
Bugged comment by template

### DIFF
--- a/ui/_my_clan.htm
+++ b/ui/_my_clan.htm
@@ -13,12 +13,6 @@
         </div>
       </div>
       
-      <hr style="border-top: 1px solid #ccc;">
-      
-      <!-- <div id="messages_list_container">
-      <include href="{{ @messages_list_component_template }}" />
-      </div> -->
-      
       <hr style="border-top: 1px solid #ccc;">      
       
       <div class="span11">


### PR DESCRIPTION
I needed to entirely remove these lines:

<hr style="border-top: 1px solid #ccc;">

<div id="messages_list_container">
<include href="{{ @messages_list_component_template }}" />
</div>


Templete runs no matter it's commented. Because of this, there were some
unwanted letters visible on page. Now, they're gone.
